### PR TITLE
Fix: Export AnimatedStatus class using module.exports

### DIFF
--- a/Animated_Status.plugin.js
+++ b/Animated_Status.plugin.js
@@ -339,3 +339,5 @@ const GUI = {
     return element;
   },
 };
+
+module.exports = AnimatedStatus;


### PR DESCRIPTION
## Summary

BetterDiscord currently rejects this plugin with

> Plugin not a valid format.

The plugin defines the AnimatedStatus class but never exports it.

## Changes

- Add `module.exports = AnimatedStatus;`

This restores compatibility with BetterDiscord's plugin loader.